### PR TITLE
fix: dark mode input on mounted unchange

### DIFF
--- a/components/Layouts/Sidebar/Dark.vue
+++ b/components/Layouts/Sidebar/Dark.vue
@@ -3,7 +3,7 @@
 const THEME_KEY = "theme"
 const THEME_REGEX = /\btheme-[a-z0-9]+\b/g
 
-const toggler = document.getElementById("toggle-dark") as HTMLInputElement
+const darkToggler = ref()
 /**
  * Toggle Dark Mode
  */
@@ -23,7 +23,7 @@ const toggleDarkTheme = () => {
 const setTheme = (theme: string, dontPersist: boolean = false) => {
   document.body.className = document.body.className.replace(THEME_REGEX, "")
   document.body.classList.add(theme)
-  if (toggler) toggler.checked = theme == "theme-dark"
+  if (darkToggler) darkToggler.value.checked = theme == "theme-dark"
 
   if (!dontPersist) {
     localStorage.setItem(THEME_KEY, theme)
@@ -78,7 +78,7 @@ onMounted(() => {
       </g>
     </svg>
     <div class="form-check form-switch fs-6">
-      <input class="form-check-input me-0" type="checkbox" id="toggle-dark" style="cursor: pointer" @click="toggleDarkTheme"/>
+      <input class="form-check-input me-0" type="checkbox" id="toggle-dark" ref="darkToggler" style="cursor: pointer" @click="toggleDarkTheme"/>
       <label class="form-check-label"></label>
     </div>
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img"

--- a/components/Layouts/Sidebar/LayoutSidebar.vue
+++ b/components/Layouts/Sidebar/LayoutSidebar.vue
@@ -83,9 +83,7 @@ watch(() => store.isSidebarActive, (isSidebarActive) => {
           <div class="logo">
             <nuxt-link to="/"><img src="~/assets/images/logo/logo.png" alt="Logo"></nuxt-link>
           </div>
-          <client-only>
-            <Dark />
-          </client-only>
+          <Dark />
           <div class="toggler">
             <a href="#" class="sidebar-hide d-xl-none d-block" @click="store.toggleSidebar">
               <i class="bi bi-x bi-middle"></i>


### PR DESCRIPTION
1. change dark toggler to refs so it can be call on universal mode
2. remove client only tag on sidebar layout to load the element on first load

<!--
Thanks for wanting to fix something on Mazer Nuxt!

Please use a semantic commit message for your PR name
-->

## Description
To resolve issue on #299 before this PR, the dark component only load on client side. It makes the components doesnt load on the first second and appear latter on. Also fix bugs onmounted, the dark mode doesnt update the checkbox to true even if its on dark mode.
<!-- Please provide a description of the change here. -->

<!-- Closes #??? -->

## Todos

- [x] 1. change dark toggler from document.getElementById to vue refs
- [x] 2. remove client-only tag from sidebar dark component